### PR TITLE
Yieldless / instant-start animations + extras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 *.rbxl
-bin/installer.lua

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Roact"]
+	path = Roact
+	url = https://github.com/Roblox/Roact

--- a/README.md
+++ b/README.md
@@ -4,66 +4,7 @@ An animation library for [Roact](https://github.com/Roblox/Roact) modeled after 
 ## Installation
 There are two ways to install `roact-animate`. The recommended way is to download the installer from the [latest release](https://github.com/AmaranthineCodices/roact-material/releases/latest) and run it from Studio's Run Script option (in the Test tab). Alternatively, you can download the repository's `src` directory manually and get it into Roblox Studio. You can use [Rojo](https://github.com/LPGhatguy/rojo) or a similar plugin for this.
 
-Regardless of which method you use, if Roact is **not** installed in `ReplicatedStorage`, you will need to change the `makeAnimatedComponent` module to account for that. Specifically, where it requires Roact in:
-
-```lua
-local Roact = require(game:GetService("ReplicatedStorage").Roact)
-```
-
-Change it to
-```lua
-local Roact = -- however you choose to import Roact
-```
+`roact-animate` must be installed in the same location as Roact.
 
 ## Usage
-Documentation coming soon<sup>tm</sup>. Here's a quick example:
-
-```lua
-local Roact = require(game.ReplicatedStorage.Roact)
-local RoactAnimate = require(game.ReplicatedStorage.RoactAnimate)
-
-local TestComponent = Roact.Component:extend("AnimateTest")
-
-function TestComponent:init()
-	self.state = {
-		Transparency = RoactAnimate.Value.new(1);
-		Size = RoactAnimate.Value.new(UDim2.new(0, 100, 0, 100));
-		Color = RoactAnimate.Value.new(Color3.new(1, 1, 1));
-	}
-end
-
-function TestComponent:didMount()
-	spawn(function()
-		wait(1)
-		RoactAnimate.Sequence({
-			RoactAnimate(
-				self.state.Transparency,
-				TweenInfo.new(1),
-				0),
-			RoactAnimate.Parallel({
-				RoactAnimate(self.state.Size,
-					TweenInfo.new(0.5),
-					UDim2.new(0, 200, 0, 50)),
-				RoactAnimate(self.state.Color,
-					TweenInfo.new(0.5),
-					Color3.new(0.5, 0.1, 1)),
-			})
-		}):Start()
-	end)
-end
-
-function TestComponent:render()
-	return Roact.createElement(RoactAnimate.Frame, {
-		BackgroundTransparency = self.state.Transparency;
-		Position = UDim2.new(0.5, 0, 0.5, 0);
-		Size = self.state.Size;
-		BackgroundColor3 = self.state.Color;
-	}, self.props[Roact.Children])
-end
-
-local testTree = Roact.createElement("ScreenGui", {}, {
-	Roact.createElement(TestComponent)
-})
-
-Roact.reify(testTree, game.Players.LocalPlayer:WaitForChild("PlayerGui"))
-```
+Documentation coming soon<sup>tm</sup>. Check the `examples` folder for some examples of how to use this.

--- a/bin/build-installer.lua
+++ b/bin/build-installer.lua
@@ -1,1 +1,0 @@
-os.exit(os.execute("rbxpacker --folder RoactAnimate --name RoactAnimate ./src > bin/installer.lua"))

--- a/examples/basic.client.lua
+++ b/examples/basic.client.lua
@@ -1,0 +1,55 @@
+local Roact = require(game.ReplicatedStorage.Roact)
+local RoactAnimate = require(game.ReplicatedStorage.RoactAnimate)
+
+local TestComponent = Roact.Component:extend("AnimateTest")
+
+function TestComponent:init()
+	self.state = {
+		Transparency = RoactAnimate.Value.new(1);
+		Size = RoactAnimate.Value.new(UDim2.new(0, 100, 0, 100));
+		Color = RoactAnimate.Value.new(Color3.new(1, 1, 1));
+	}
+end
+
+function TestComponent:didMount()
+	spawn(function()
+		while true do
+			wait(5)
+
+			RoactAnimate.Sequence({
+				RoactAnimate.Parallel({
+					RoactAnimate.Prepare(self.state.Transparency, 1),
+					RoactAnimate.Prepare(self.state.Size, UDim2.new(0, 100, 0, 100)),
+					RoactAnimate.Prepare(self.state.Color, Color3.new(1, 1, 1)),
+				}),
+				RoactAnimate(
+					self.state.Transparency,
+					TweenInfo.new(1),
+					0),
+				RoactAnimate.Parallel({
+					RoactAnimate(self.state.Size,
+						TweenInfo.new(0.5),
+						UDim2.new(0, 200, 0, 50)),
+					RoactAnimate(self.state.Color,
+						TweenInfo.new(0.5),
+						Color3.new(0.5, 0.1, 1)),
+				})
+			}):Start()
+		end
+	end)
+end
+
+function TestComponent:render()
+	return Roact.createElement(RoactAnimate.Frame, {
+		BackgroundTransparency = self.state.Transparency;
+		Position = UDim2.new(0.5, 0, 0.5, 0);
+		Size = self.state.Size;
+		BackgroundColor3 = self.state.Color;
+	}, self.props[Roact.Children])
+end
+
+local testTree = Roact.createElement("ScreenGui", {}, {
+	Roact.createElement(TestComponent)
+})
+
+Roact.mount(testTree, game.Players.LocalPlayer:WaitForChild("PlayerGui"))

--- a/rojo.json
+++ b/rojo.json
@@ -1,0 +1,18 @@
+{
+  "name": "roact-animate",
+  "servePort": 8000,
+  "partitions": {
+    "src": {
+      "path": "src",
+      "target": "ReplicatedStorage.RoactAnimate"
+    },
+    "roact-lib": {
+      "path": "Roact/lib",
+      "target": "ReplicatedStorage.Roact"
+    },
+    "examples": {
+      "path": "examples",
+      "target": "StarterPlayer.StarterPlayerScripts.RoactAnimateExamples"
+    }
+  }
+}

--- a/src/AnimatedValue.lua
+++ b/src/AnimatedValue.lua
@@ -1,38 +1,35 @@
 -- Represents an animated value.
 -- This is literally a Lua implementation of a generic *Value.
 
+local Signal = require(script.Parent.Signal)
+
 local Value = {}
 Value.__index = Value
 
 function Value.new(initial)
 	local self = setmetatable({
-		Value = initial;
-		_valueType = typeof(initial);
-		_startAnimation = Instance.new("BindableEvent");
-		_finishAnimation = Instance.new("BindableEvent");
-		_change = Instance.new("BindableEvent");
-		_class = Value;
+		Value = initial,
+		_valueType = typeof(initial),
+		AnimationStarted = Signal.new(),
+		AnimationFinished = Signal.new(),
+		Changed = Signal.new(),
+		_class = Value,
 	}, Value)
-
-	self.AnimationStarted = self._startAnimation.Event
-	self.AnimationFinished = self._finishAnimation.Event
-	self.Changed = self._change.Event
 
 	return self
 end
 
 function Value:Change(newValue)
 	self.Value = newValue
-	self._change:Fire(newValue)
+	self.Changed:Fire(newValue)
 end
 
 function Value:StartAnimation(toValue, tweenInfo)
-	self._startAnimation:Fire(toValue, tweenInfo)
+	self.AnimationStarted:Fire(toValue, tweenInfo)
 end
 
 function Value:FinishAnimation()
-	self.Done = true
-	self._finishAnimation:Fire()
+	self.AnimationFinished:Fire()
 end
 
 return Value

--- a/src/AnimatedValue.lua
+++ b/src/AnimatedValue.lua
@@ -6,10 +6,12 @@ local Signal = require(script.Parent.Signal)
 local Value = {}
 Value.__index = Value
 
+--[[
+	Creates a new value with a starting inner value.
+]]
 function Value.new(initial)
 	local self = setmetatable({
 		Value = initial,
-		_valueType = typeof(initial),
 		AnimationStarted = Signal.new(),
 		AnimationFinished = Signal.new(),
 		Changed = Signal.new(),
@@ -19,15 +21,25 @@ function Value.new(initial)
 	return self
 end
 
+--[[
+	Triggers a change in the value. This immediately changes the value for all
+	objects it is used in, with no animation.
+]]
 function Value:Change(newValue)
 	self.Value = newValue
 	self.Changed:Fire(newValue)
 end
 
+--[[
+	Starts an animation over the property's value, using supplied tween properties.
+]]
 function Value:StartAnimation(toValue, tweenInfo)
 	self.AnimationStarted:Fire(toValue, tweenInfo)
 end
 
+--[[
+	Finishes an animation; called by animated components.
+]]
 function Value:FinishAnimation()
 	self.AnimationFinished:Fire()
 end

--- a/src/Animation.lua
+++ b/src/Animation.lua
@@ -1,18 +1,18 @@
+local Signal = require(script.Parent.Signal)
+
 local Animation = {}
 Animation.__index = Animation
 
 function Animation.new(value, tweenInfo, to)
 	local self = setmetatable({
-		_value = value;
-		_tween = tweenInfo;
-		_to = to;
-		_finished = Instance.new("BindableEvent");
+		_value = value,
+		_tween = tweenInfo,
+		_to = to,
+		AnimationFinished = Signal.new(),
 	}, Animation)
 
-	self.AnimationFinished = self._finished.Event
-
 	value.AnimationFinished:Connect(function(...)
-		self._finished:Fire(...)
+		self.AnimationFinished:Fire(...)
 	end)
 
 	return self

--- a/src/Animation.lua
+++ b/src/Animation.lua
@@ -1,8 +1,16 @@
+--[[
+	An animation over a single value to a single other value.
+	Combined via AnimationSequence to produce coordinated animations.
+]]
+
 local Signal = require(script.Parent.Signal)
 
 local Animation = {}
 Animation.__index = Animation
 
+--[[
+	Creates a new Animation.
+]]
 function Animation.new(value, tweenInfo, to)
 	local self = setmetatable({
 		_value = value,
@@ -11,6 +19,8 @@ function Animation.new(value, tweenInfo, to)
 		AnimationFinished = Signal.new(),
 	}, Animation)
 
+	-- When the value finishes an animation, fire this Animation's finished
+	-- signal as well, to allow AnimationSequence to properly sequence things.
 	value.AnimationFinished:Connect(function(...)
 		self.AnimationFinished:Fire(...)
 	end)
@@ -18,6 +28,9 @@ function Animation.new(value, tweenInfo, to)
 	return self
 end
 
+--[[
+	Starts the animation.
+]]
 function Animation:Start()
 	self._value:StartAnimation(self._to, self._tween)
 end

--- a/src/AnimationSequence.lua
+++ b/src/AnimationSequence.lua
@@ -3,6 +3,9 @@ local Signal = require(script.Parent.Signal)
 local AnimationSequence = {}
 AnimationSequence.__index = AnimationSequence
 
+--[[
+	Creates a new animation sequence.
+]]
 function AnimationSequence.new(animations, parallel)
 	local self = setmetatable({
 		_animations = animations,
@@ -13,6 +16,13 @@ function AnimationSequence.new(animations, parallel)
 	return self
 end
 
+--[[
+	Starts the animation sequence. All animations are run asynchronously; this
+	method does not yield!
+
+	If called when the animation sequence is already playing, this will halt
+	the current sequence and start over from the beginning.
+]]
 function AnimationSequence:Start()
 	-- Do all of this asynchronously.
 	spawn(function()

--- a/src/PrepareStep.lua
+++ b/src/PrepareStep.lua
@@ -1,25 +1,24 @@
 -- A "prepare" step.
 -- Exposes the same API as Animation/AnimationSequence, but instantly completes its goal.
 
+local Signal = require(script.Parent.Signal)
+
 local PrepareStep = {}
 PrepareStep.__index = PrepareStep
 
 function PrepareStep.new(value, to)
     local self = setmetatable({
-        _value = value;
-        _to = to;
-        _finished = Instance.new("BindableEvent");
+        _value = value,
+        _to = to,
+        AnimationFinished = Signal.new(),
     }, PrepareStep)
-
-    self.AnimationFinished = self._finished.Event
 
     return self
 end
 
 function PrepareStep:Start()
     self._value:Change(self._to)
-    self.Done = true
-    self._finished:Fire()
+    self.AnimationFinished:Fire()
 end
 
 return PrepareStep

--- a/src/PrepareStep.lua
+++ b/src/PrepareStep.lua
@@ -1,5 +1,7 @@
--- A "prepare" step.
--- Exposes the same API as Animation/AnimationSequence, but instantly completes its goal.
+--[[
+    A "prepare" step.
+    Exposes the same API as Animation/AnimationSequence, but instantly completes its goal.
+]]
 
 local Signal = require(script.Parent.Signal)
 
@@ -16,6 +18,9 @@ function PrepareStep.new(value, to)
     return self
 end
 
+--[[
+    "Starts" the step, instantly changing the value to the specified new value.
+]]
 function PrepareStep:Start()
     self._value:Change(self._to)
     self.AnimationFinished:Fire()

--- a/src/Signal.lua
+++ b/src/Signal.lua
@@ -1,0 +1,35 @@
+--[[
+	A signal that calls listeners synchronously.
+]]
+
+local Signal = {}
+Signal.__index = Signal
+
+function Signal.new()
+	return setmetatable({
+		_listeners = {},
+	}, Signal)
+end
+
+function Signal:Connect(listener)
+	table.insert(self._listeners, listener)
+
+	return {
+		Disconnect = function()
+			for i = #self._listeners, 1, -1 do
+				if self._listeners[i] == listener then
+					table.remove(self._listeners, i)
+					break
+				end
+			end
+		end,
+	}
+end
+
+function Signal:Fire(...)
+	for _, listener in ipairs(self._listeners) do
+		listener(...)
+	end
+end
+
+return Signal

--- a/src/init.lua
+++ b/src/init.lua
@@ -7,33 +7,34 @@ for _, class in ipairs({ "Frame", "ImageLabel", "ImageButton", "TextButton", "Te
 	RoactAnimate[class] = makeAnimatedComponent(class)
 end
 
+local Animation = require(script.Animation)
+local AnimationSequence = require(script.AnimationSequence)
+local PrepareStep = require(script.PrepareStep)
+
 RoactAnimate.Value = require(script.AnimatedValue)
 RoactAnimate.makeAnimatedComponent = makeAnimatedComponent
-RoactAnimate.Animation = require(script.Animation)
-RoactAnimate.AnimationSequence = require(script.AnimationSequence)
-RoactAnimate.PrepareStep = require(script.PrepareStep)
 
 -- Creates an animation for a value.
 function RoactAnimate.Animate(value, tweenInfo, to)
-	return RoactAnimate.Animation.new(value, tweenInfo, to)
+	return Animation.new(value, tweenInfo, to)
 end
 
 -- Creates an animation from a table of animations.
 -- These animations will be run one-by-one.
 function RoactAnimate.Sequence(animations)
-	return RoactAnimate.AnimationSequence.new(animations, false)
+	return AnimationSequence.new(animations, false)
 end
 
 -- Creates an animation from a table of animations.
 -- These animations will be run all at once.
 function RoactAnimate.Parallel(animations)
-	return RoactAnimate.AnimationSequence.new(animations, true)
+	return AnimationSequence.new(animations, true)
 end
 
 -- Creates a preparation step.
 -- This allows instantaneous resetting of a value prior to animations completing.
 function RoactAnimate.Prepare(value, to)
-	return RoactAnimate.PrepareStep.new(value, to)
+	return PrepareStep.new(value, to)
 end
 
 setmetatable(RoactAnimate, { __call = function(_, ...) return RoactAnimate.Animate(...) end; })

--- a/src/makeAnimatedComponent.lua
+++ b/src/makeAnimatedComponent.lua
@@ -1,14 +1,22 @@
 -- Wraps a component to produce a new component that responds to animated values.
 
+local NON_PRIMITIVE_ERROR = "The component %q cannot be animated because it is not a primitive component."
+
 local TweenService = game:GetService("TweenService")
 
 local Roact = require(script.Parent.Parent.Roact)
 local AnimatedValue = require(script.Parent.AnimatedValue)
 
 local function makeAnimatedComponent(toWrap)
+	-- Non-primitive components cannot be animated because you can't use refs
+	-- with them.
+	if typeof(toWrap) ~= "string" then
+		error(NON_PRIMITIVE_ERROR:format(tostring(toWrap)), 2)
+	end
+
 	-- Component name is weird(ish) to avoid name collisions
 	-- This is automatically created, so w/e
-	local wrappedComponent = Roact.Component:extend("_animatedComponent:"..tostring(toWrap))
+	local wrappedComponent = Roact.Component:extend("_animatedComponent:"..toWrap)
 
 	function wrappedComponent:didMount()
 		-- Disconnect any currently registered listeners, just in case.

--- a/src/makeAnimatedComponent.lua
+++ b/src/makeAnimatedComponent.lua
@@ -35,7 +35,7 @@ local function makeAnimatedComponent(toWrap)
 						-- Theoretically there are optimizations that could be done here, but
 						-- it's much simpler to just do one-tween-per-property.
 						-- Is optimizing this even relevant?
-						local tween = TweenService:Create(self._rbx, tweenInfo, { [key] = to; })
+						local tween = TweenService:Create(self._rbx, tweenInfo, { [key] = to, })
 						tween:Play()
 						_currentTween = tween
 


### PR DESCRIPTION
Switches the entire animation system away from using BindableEvents. This has a number of benefits:

* Animations now start on the same frame that you call `Start`
* PrepareSteps now actually execute instantly (fixes #3)
* No more yielding!
* No more instance churning when you start animations
  Previously, a `BindableEvent` object would be created by each `AnimationSequence` and used for flow-control purposes. This is no longer the case!

Other changes:
* #5 is fixed; `makeAnimatedComponent` throws if given a non-string
* Codebase is cleaner and has more comments
* Tiny example / testbed added, with full Rojo support