### PR TITLE
Proposed fix for memory leaks

### DIFF
--- a/src/AnimatedValue.lua
+++ b/src/AnimatedValue.lua
@@ -16,6 +16,7 @@ function Value.new(initial)
 		AnimationFinished = Signal.new(),
 		Changed = Signal.new(),
 		_class = Value,
+		_isAnimating = false,
 	}, Value)
 
 	return self
@@ -34,14 +35,20 @@ end
 	Starts an animation over the property's value, using supplied tween properties.
 ]]
 function Value:StartAnimation(toValue, tweenInfo)
+	if self._isAnimating then
+		self:FinishAnimation(false)
+	end
+
+	self._isAnimating = true
 	self.AnimationStarted:Fire(toValue, tweenInfo)
 end
 
 --[[
 	Finishes an animation; called by animated components.
 ]]
-function Value:FinishAnimation()
-	self.AnimationFinished:Fire()
+function Value:FinishAnimation(wasCompleted)
+	self._isAnimating = false
+	self.AnimationFinished:Fire(wasCompleted)
 end
 
 return Value

--- a/src/Animation.lua
+++ b/src/Animation.lua
@@ -19,12 +19,6 @@ function Animation.new(value, tweenInfo, to)
 		AnimationFinished = Signal.new(),
 	}, Animation)
 
-	-- When the value finishes an animation, fire this Animation's finished
-	-- signal as well, to allow AnimationSequence to properly sequence things.
-	value.AnimationFinished:Connect(function(...)
-		self.AnimationFinished:Fire(...)
-	end)
-
 	return self
 end
 
@@ -32,6 +26,15 @@ end
 	Starts the animation.
 ]]
 function Animation:Start()
+	-- When the value finishes an animation, fire this Animation's finished
+	-- signal as well, to allow AnimationSequence to properly sequence things.
+	local connection
+	connection = self._value.AnimationFinished:Connect(function(wasCompleted, ...)
+		connection:Disconnect()
+		
+		self.AnimationFinished:Fire(wasCompleted, ...)
+	end)
+
 	self._value:StartAnimation(self._to, self._tween)
 end
 

--- a/src/AnimationSequence.lua
+++ b/src/AnimationSequence.lua
@@ -33,14 +33,17 @@ function AnimationSequence:Start()
 			local count = #self._animations
 
 			for _, animation in ipairs(self._animations) do
+				local allCompleted = true
 				local connection
-				connection = animation.AnimationFinished:Connect(function()
+				connection = animation.AnimationFinished:Connect(function(wasCompleted)
 					connection:Disconnect()
 					count = count - 1
 
+					allCompleted = allCompleted and wasCompleted
+
 					-- If all of the animations are done, fire the AnimationFinished signal.
 					if count <= 0 then
-						self.AnimationFinished:Fire()
+						self.AnimationFinished:Fire(allCompleted)
 					end
 				end)
 
@@ -65,17 +68,21 @@ function AnimationSequence:_startSequential(index)
 	local animation = self._animations[index]
 
 	local connection
-	connection = animation.AnimationFinished:Connect(function()
+	connection = animation.AnimationFinished:Connect(function(wasCompleted)
 		connection:Disconnect()
 
-		local newIndex = index + 1
-		-- If the index is greater than the length of the table, this was the
-		-- last animation - we're done!
-		if newIndex > #self._animations then
-			self.AnimationFinished:Fire()
-		-- Otherwise, go on to the next animation.
+		if wasCompleted then
+			local newIndex = index + 1
+			-- If the index is greater than the length of the table, this was the
+			-- last animation - we're done!
+			if newIndex > #self._animations then
+				self.AnimationFinished:Fire(true)
+			-- Otherwise, go on to the next animation.
+			else
+				self:_startSequential(newIndex)
+			end
 		else
-			self:_startSequential(newIndex)
+			self.AnimationFinished:Fire(false)
 		end
 	end)
 

--- a/src/PrepareStep.lua
+++ b/src/PrepareStep.lua
@@ -23,7 +23,7 @@ end
 ]]
 function PrepareStep:Start()
     self._value:Change(self._to)
-    self.AnimationFinished:Fire()
+    self.AnimationFinished:Fire(true)
 end
 
 return PrepareStep

--- a/src/Signal.lua
+++ b/src/Signal.lua
@@ -1,6 +1,18 @@
 --[[
-	A signal that calls listeners synchronously.
+	A signal that calls listeners [a]synchronously.
 ]]
+
+local function wrapInPointer(...)
+	local args = { ... }
+	return function()
+		return unpack(args)
+	end
+end
+
+local FastSpawn = Instance.new("BindableEvent")
+FastSpawn.Event:Connect(function(callback, pointer)
+	callback(pointer())
+end)
 
 local Signal = {}
 Signal.__index = Signal
@@ -28,7 +40,7 @@ end
 
 function Signal:Fire(...)
 	for _, listener in ipairs(self._listeners) do
-		listener(...)
+		FastSpawn:Fire(listener, wrapInPointer(...))
 	end
 end
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -3,7 +3,15 @@ local makeAnimatedComponent = require(script.makeAnimatedComponent)
 local RoactAnimate = {}
 
 -- Create animated variants of all the Roblox classes
-for _, class in ipairs({ "Frame", "ImageLabel", "ImageButton", "TextButton", "TextBox", "TextLabel", "ScrollingFrame" }) do
+for _, class in ipairs({
+		"Frame",
+		"ImageLabel",
+		"ImageButton",
+		"TextButton",
+		"TextBox",
+		"TextLabel",
+		"ScrollingFrame"
+	}) do
 	RoactAnimate[class] = makeAnimatedComponent(class)
 end
 

--- a/src/makeAnimatedComponent.lua
+++ b/src/makeAnimatedComponent.lua
@@ -4,7 +4,8 @@ local NON_PRIMITIVE_ERROR = "The component %q cannot be animated because it is n
 
 local TweenService = game:GetService("TweenService")
 
-local Roact = require(script.Parent.Parent.Roact)
+local RoactModule = game:GetService("ReplicatedStorage"):FindFirstChild("rbx-roact", true)
+local Roact = require(RoactModule.roact.lib)
 local AnimatedValue = require(script.Parent.AnimatedValue)
 
 local function makeAnimatedComponent(toWrap)
@@ -48,12 +49,17 @@ local function makeAnimatedComponent(toWrap)
 						_currentTween = tween
 
 						-- For feedback - this is used for sequential animations
-						_currentTween.Completed:Connect(function(status)
-							-- Only "finish" the animation if it wasn't canceled.
-							if status == Enum.PlaybackState.Completed then
-								value:FinishAnimation()
-							end
-						end)
+						local finishStatus = _currentTween.Completed:Wait()
+						if finishStatus == Enum.PlaybackState.Completed then
+							-- Finish animation marked as "completed"
+							value:FinishAnimation(true)
+						else
+							-- Finish animation marked as "overridden"
+							value:FinishAnimation(false)
+						end
+					else
+						-- Close animation immediately
+						value:FinishAnimation(false)
 					end
 				end))
 

--- a/src/makeAnimatedComponent.lua
+++ b/src/makeAnimatedComponent.lua
@@ -4,8 +4,7 @@ local NON_PRIMITIVE_ERROR = "The component %q cannot be animated because it is n
 
 local TweenService = game:GetService("TweenService")
 
-local RoactModule = game:GetService("ReplicatedStorage"):FindFirstChild("rbx-roact", true)
-local Roact = require(RoactModule.roact.lib)
+local Roact = require(script.Parent.Parent.Roact)
 local AnimatedValue = require(script.Parent.AnimatedValue)
 
 local function makeAnimatedComponent(toWrap)


### PR DESCRIPTION
In my TS port, I discovered that a memory leak that will occur 100% of the time a new animation is created, because of the way animations are currently handled.

These changes should solve this problem, although I think the system may need some redesigning. Currently, the behavior is changed so that

1. Signals are now asynchronous (but fire instantly so long as there is no yielding). I did this in order to make a yielding call when an animation starts, because this fix relies on the guarantee that the tween's Completed event fires (whether or not the animation has actually completed, or was just canceled)
`local finishStatus = _currentTween.Completed:Wait()`
2. AnimationFinished events should now be _guaranteed_ to fire for any created tween once it finishes, regardless of whether it made it to completion
3. AnimationFinished events have an extra parameter `wasCompleted`, which is true iff all tweened values have made it to completion. If a value is ever overridden, it will fire with `wasCompleted` set to false.
4. Because of this guarantee, all listeners related to playing animations can safely rely on being disconnected the next time AnimationFinished is called.

What this means is that an overridden tween on a value will halt the playing AnimatedValue, which will then halt the playing Animation, which will then halt the playing AnimationSequence or Parallel.

This system needs to be redesigned in the future so that the transition from one interrupting animation to the next is seamless and GC's nicely.

fixes #13 